### PR TITLE
Adicionar Bower como devDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "yargs": "^4.3.2"
   },
   "devDependencies": {
+    "bower": "^1.7.9",
     "jasmine": "^2.4.1",
     "karma": "^0.13.22",
     "karma-coverage": "^0.5.5",


### PR DESCRIPTION
Dessa maneira não se faz necessária a instalação global do Bower para executar o comando `postinstall`.

@gabriel-ribeiro-ir 