### PR TITLE
Zera o pool da aplicação quando server ficar idle

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -9,5 +9,9 @@ module.exports = {
     user: process.env.DB_USER,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME
+  },
+  pool: {
+    min: 0,
+    max: 7
   }
 };


### PR DESCRIPTION
Esse PR resolve os problemas de conexão com o banco de dados.
Pelo que entendi, sempre que o server entra em idle ele tenta manter o pool de conexão aberto, quando alguém tenta acessar depois disso, precisa refazer o request para conseguir fazer a conexão realmente.
Este problema havia sido reportado na issue #42.

Fontes de onde encontrei a solução do problema:
[Documentação do Knex](http://knexjs.org/#Installation-pooling)
[Stack Overflow](https://stackoverflow.com/questions/38637346/web-app-database-econnreset)
